### PR TITLE
Resolve clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Check lints
+      run: cargo clippy --all-targets
+    - name: Check formatting
+      run: cargo fmt --check
     - name: Run tests
       run: cargo test --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn run(args: &CliArgs) -> FshcResult {
 fn terminate(outcome: FshcResult, args: &CliArgs) {
     match outcome {
         Ok(stats) => {
-            exit(&stats, ExitCode::Ok);
+            exit(stats, ExitCode::Ok);
         }
         Err(err) => {
             let failure = Failure {
@@ -44,7 +44,7 @@ fn terminate(outcome: FshcResult, args: &CliArgs) {
                 ),
                 details: &err.to_string(),
             };
-            exit(&failure, err.exit_code());
+            exit(failure, err.exit_code());
         }
     }
 }
@@ -54,14 +54,16 @@ fn exit<T: Serialize + fmt::Debug>(data: T, code: ExitCode) {
         ExitCode::Ok => {
             println!(
                 "{}",
-                serde_json::to_string(&data).expect(&format!("could not serialize {:?}", data))
+                serde_json::to_string(&data)
+                    .unwrap_or_else(|err| panic!("could not serialize {:?}: {}", data, err))
             );
             std::process::exit(code as i32);
         }
         _ => {
             eprintln!(
                 "{}",
-                serde_json::to_string(&data).expect(&format!("could not serialize {:?}", data))
+                serde_json::to_string(&data)
+                    .unwrap_or_else(|err| panic!("could not serialize {:?}: {}", data, err))
             );
             std::process::exit(code as i32);
         }


### PR DESCRIPTION
Clippy has a few suggestions I've applied here:

* Some small style changes in the fds module
* Remove unnecessary borrows when calling `exit`
* Switch from `expect` to `unwrap_or_else`. The old version would allocate the String for the `expect` even if the serialization succeeded. Switching to `unwrap_or_else` lets us avoid that.

I also added clippy and formatter checks to the CI.