### PR TITLE
Count file handles on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,25 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --verbose
     - name: Check lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "serde_json",
  "sysexits",
  "thiserror",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ procfs = "0.15"
 
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 libproc = "0.13"
+
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.48"
+features = [
+  "Win32_System_WindowsProgramming",
+  "Win32_Foundation"
+]

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -1,3 +1,6 @@
+#[cfg(target_os = "windows")]
+mod windows;
+
 use crate::outcome::*;
 #[cfg(target_os = "macos")]
 use libproc::libproc::{

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -12,9 +12,9 @@ pub struct FdList;
 
 #[cfg(target_os = "macos")]
 impl FdList {
-    pub fn list(pid: i32) -> Result<ProcStats, FshcError> {
-        let info = pidinfo::<BSDInfo>(pid, 0)?;
-        let fds = listpidinfo::<ListFDs>(pid, info.pbi_nfiles as usize)?;
+    pub fn list(pid: Pid) -> Result<ProcStats, FshcError> {
+        let info = pidinfo::<BSDInfo>(pid as i32, 0)?;
+        let fds = listpidinfo::<ListFDs>(pid as i32, info.pbi_nfiles as usize)?;
 
         let mut stats = ProcStats {
             pid,
@@ -38,8 +38,8 @@ impl FdList {
 
 #[cfg(target_os = "linux")]
 impl FdList {
-    pub fn list(pid: i32) -> Result<ProcStats, FshcError> {
-        let proc = Process::new(pid)?;
+    pub fn list(pid: Pid) -> Result<ProcStats, FshcError> {
+        let proc = Process::new(pid as i32)?;
         let all_fds = proc.fd()?;
 
         let mut stats = ProcStats {

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -16,11 +16,7 @@ impl FdList {
         let info = pidinfo::<BSDInfo>(pid as i32, 0)?;
         let fds = listpidinfo::<ListFDs>(pid as i32, info.pbi_nfiles as usize)?;
 
-        let mut stats = ProcStats {
-            pid,
-            socket_descriptors: 0,
-            file_descriptors: 0,
-        };
+        let mut stats = ProcStats::new(pid);
         for fd in fds {
             // libproc returns file descriptor types as numbers,
             // try to convert them
@@ -42,11 +38,7 @@ impl FdList {
         let proc = Process::new(pid as i32)?;
         let all_fds = proc.fd()?;
 
-        let mut stats = ProcStats {
-            pid,
-            socket_descriptors: 0,
-            file_descriptors: 0,
-        };
+        let mut stats = ProcStats::new(pid);
         let fds = all_fds
             .flatten()
             .filter(|fd_info| matches!(fd_info.target, FDTarget::Path(_) | FDTarget::Socket(_)));

--- a/src/fds/windows.rs
+++ b/src/fds/windows.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+use std::ffi::c_void;
+use windows_sys::Win32::{
+    Foundation::{STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS},
+    System::WindowsProgramming::{
+        // https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation
+        NtQuerySystemInformation as nt_query_system_information,
+        SYSTEM_INFORMATION_CLASS,
+    },
+};
+
+/// The type ID of "File" kernel objects.
+const FILE_HANDLE_OBJECT_TYPE_ID: u8 = 37;
+
+// The system handle information request and response are not
+// officially documented so we need to write our own type wrappers.
+
+/// A system information class value that retrieves all handles
+/// from the kernel.
+const SYSTEM_HANDLE_INFORMATION: SYSTEM_INFORMATION_CLASS = 0x10;
+const SYSTEM_HANDLE_INFO_BUFFER_SIZE: usize = 262144; // 2^18
+
+/// Information about a kernel object handle.
+/// See <https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/handle_table_entry.htm>
+#[repr(C)]
+#[derive(Debug)]
+struct SystemHandleTableEntryInfo {
+    /// The ID of the process which holds the handle.
+    process_id: u16,
+    _creator_back_trace_index: u16,
+    /// The type of object described by the handle.
+    /// See `FILE_HANDLE_OBJECT_TYPE_ID`.
+    object_type_id: u8,
+    _handle_attributes: u8,
+    _handle: u16,
+    _object: *mut c_void,
+    _granted_access: u32,
+}
+
+/// A vector of all kernel object handles in the system.
+/// See <https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/handle.htm>
+#[repr(C)]
+#[derive(Debug)]
+struct SystemHandleInformation {
+    number_of_handles: u32,
+    /// 1-length arrays are interpreted as any-length arrays.
+    /// This value should be used as a pointer and re-cast into a slice
+    /// `[SystemHandleTableEntryInfo; number_of_handles]`.
+    handles: [SystemHandleTableEntryInfo; 1],
+}
+
+impl FdList {
+    pub fn list(pid: Pid) -> Result<ProcStats, FshcError> {
+        let mut stats = ProcStats::new(pid);
+
+        // Get the list of all open kernel object handles.
+        let mut buffer: Vec<usize> = Vec::with_capacity(SYSTEM_HANDLE_INFO_BUFFER_SIZE);
+        loop {
+            buffer.resize(buffer.len() + SYSTEM_HANDLE_INFO_BUFFER_SIZE, 0);
+            let mut return_length: u32 = 0;
+            match unsafe {
+                nt_query_system_information(
+                    SYSTEM_HANDLE_INFORMATION,
+                    buffer.as_mut_ptr() as *mut c_void,
+                    buffer.len() as u32,
+                    &mut return_length,
+                )
+            } {
+                // We can't query the size of the list so we query
+                // repeatedly, increasing the size of the input buffer
+                // linearly on each iteration.
+                STATUS_INFO_LENGTH_MISMATCH => continue,
+                STATUS_SUCCESS => break,
+                other => return Err(format!("Quering the kernel failed with code {other}").into()),
+            }
+        }
+        let handles = unsafe {
+            let info = &*(buffer.as_ptr() as *const SystemHandleInformation);
+            std::slice::from_raw_parts(info.handles.as_ptr(), info.number_of_handles as usize)
+        };
+
+        // Count file object handles belonging to the given process.
+        for handle in handles {
+            if handle.process_id == pid as u16
+                && handle.object_type_id == FILE_HANDLE_OBJECT_TYPE_ID
+            {
+                stats.file_descriptors += 1;
+            }
+        }
+
+        Ok(stats)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,13 +70,10 @@ fn exit<T: Serialize + fmt::Debug>(data: T, code: ExitCode) {
     }
 }
 
-fn validate_pid(args: &CliArgs) -> Result<i32, FshcError> {
-    if args.pid > PID_LIMIT {
-        return Err(FshcError::PidOutOfRange);
-    }
-
-    match TryInto::<i32>::try_into(args.pid) {
-        Ok(val) => Ok(val),
-        Err(_) => Err(FshcError::InvalidInput),
+fn validate_pid(args: &CliArgs) -> Result<Pid, FshcError> {
+    if (1..=PID_LIMIT).contains(&args.pid) {
+        Ok(args.pid)
+    } else {
+        Err(FshcError::PidOutOfRange)
     }
 }

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -42,7 +42,7 @@ pub enum FshcError {
     IoError,
     #[error("failed to fetch file descriptor details for the target process")]
     Other,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     #[error("{0}")]
     Errno(String),
 }
@@ -61,7 +61,7 @@ impl ExitCodeProvider for FshcError {
             FshcError::IoError => ExitCode::IoErr,
             FshcError::InvalidInput => ExitCode::DataErr,
             FshcError::Other => ExitCode::OsErr,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             FshcError::Errno(_) => ExitCode::OsErr,
         }
     }
@@ -105,7 +105,7 @@ impl From<io::Error> for FshcError {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 impl From<String> for FshcError {
     fn from(value: String) -> Self {
         FshcError::Errno(value)

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -5,9 +5,11 @@ use std::io;
 use sysexits::ExitCode;
 use thiserror::Error;
 
+pub type Pid = u32;
+
 #[derive(Debug, Serialize)]
 pub struct ProcStats {
-    pub pid: i32,
+    pub pid: Pid,
     pub socket_descriptors: u32,
     pub file_descriptors: u32,
 }
@@ -20,7 +22,7 @@ pub struct Failure<'a> {
 
 #[derive(Error, Debug)]
 pub enum FshcError {
-    #[error("pid numbers greatr than 99999 are not supported")]
+    #[error("only pid numbers between 1 and 99999 are supported")]
     PidOutOfRange,
     #[error("could not locate a process for the given pid")]
     InvalidInput,

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -14,6 +14,16 @@ pub struct ProcStats {
     pub file_descriptors: u32,
 }
 
+impl ProcStats {
+    pub fn new(pid: Pid) -> Self {
+        Self {
+            pid,
+            socket_descriptors: 0,
+            file_descriptors: 0,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Failure<'a> {
     pub message: &'a str,


### PR DESCRIPTION
Counting file handles on Windows is tricky because there isn't an API to list the kernel object handles for a process. Instead we have to list all kernel object handles and find those that are for the given process ID, and then count the ones that are file handles. c4108cd8 has more details.

This doesn't add socket descriptor support for Windows yet. I believe sockets might count as file handles so we may need to inspect the file handles more closely to figure out how many socket handlers are open.

I also threw in a few small style changes but I could drop them if they're in the way.

Connects #1 